### PR TITLE
New --api_version argument 

### DIFF
--- a/check_docker
+++ b/check_docker
@@ -7,8 +7,9 @@ import nagiosplugin
 
 class Docker(nagiosplugin.Resource):
 
-    def __init__(self, url):
+    def __init__(self, url, api_version):
         self.url = url
+        self.api_version = api_version
 
     def probe(self):
         '''Checks docker stats.
@@ -25,7 +26,7 @@ class Docker(nagiosplugin.Resource):
         `events_listeners` are the number of events listener processes.
         '''
 
-        conn = docker.Client(base_url=self.url, timeout=20)
+        conn = docker.Client(base_url=self.url, version=self.api_version, timeout=20)
 
         # try to connect the docker service, and catch an exception if we
         # can't.
@@ -75,6 +76,8 @@ def main():
     argp.add_argument('-u', '--url', metavar='URL',
                       help='URL string for Docker service.',
                       default='unix://var/run/docker.sock'),
+    argp.add_argument('-a', '--api_version', default='1.16',
+                      help='client API version (default 1.16)')
     argp.add_argument('-t', '--timeout', default=10,
                       help='abort execution after TIMEOUT seconds')
     argp.add_argument('-v', '--verbose', action='count', default=0,
@@ -83,7 +86,7 @@ def main():
     args = argp.parse_args()
 
     # create our check object, if service metric !=0, consider that critical.
-    check = nagiosplugin.Check(Docker(args.url),
+    check = nagiosplugin.Check(Docker(args.url, args.api_version),
                                nagiosplugin.ScalarContext('service', '0', '0', fmt_metric=''),
                                DockerSummary())
 


### PR DESCRIPTION
Allows overriding client API version to match server API version. 

Using this plugin with current docker-py (DEFAULT_DOCKER_API_VERSION = '1.16' from https://github.com/docker/docker-py/commit/7bc6b228b187b8de20b20e2d66518660d2cf5895) against docker daemon 1.3.3 (Server API version: 1.15) failed with the following error (after disabling exception handling):
```
DOCKER UNKNOWN: APIError: 404 Client Error: Not Found ("client and server don't have same version (client : 1.16, server: 1.15)")
```
