### PR TITLE
Bugfix thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ If you are using the socket URL to access the API, on each monitored host, you'l
 
 Service is running:
 
-    DOCKER OK | events_listeners=0 file_descriptors=10 go_routines=12 images=11 service=0;0;0
+    DOCKER OK | events_listeners=0 file_descriptors=20 go_routines=33 images=0 service=True;1:1;1:1
 
 Service is not running:
 
-	DOCKER CRITICAL - (outside range 0:0) | service=1;0;0
+    DOCKER CRITICAL - outside range 1:1 | service=False;1:1;1:1
 
 The following stats are returned:
 
@@ -97,6 +97,3 @@ To install this you can run:
 ### User Interface
 
 ![image](screenshot.png)
-
-
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Service is not running:
 
     DOCKER CRITICAL - outside range 1:1 | service=0;1:1;1:1
 
+Mind you that the latter is also returned when the user running this plugin lacks sufficient privileges to run `docker info`.
+
 The following stats are returned:
 
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ If you are using the socket URL to access the API, on each monitored host, you'l
 
 Service is running:
 
-    DOCKER OK | events_listeners=0 file_descriptors=20 go_routines=33 images=0 service=True;1:1;1:1
+    DOCKER OK | events_listeners=0 file_descriptors=20 go_routines=33 images=0 service=1;1:1;1:1
 
 Service is not running:
 
-    DOCKER CRITICAL - outside range 1:1 | service=False;1:1;1:1
+    DOCKER CRITICAL - outside range 1:1 | service=0;1:1;1:1
 
 The following stats are returned:
 

--- a/check_docker
+++ b/check_docker
@@ -85,9 +85,9 @@ def main():
 
     args = argp.parse_args()
 
-    # create our check object, if service metric !=0, consider that critical.
+    # create our check object, if service metric !=1 (True), consider that critical.
     check = nagiosplugin.Check(Docker(args.url, args.api_version),
-                               nagiosplugin.ScalarContext('service', '0', '0', fmt_metric=''),
+                               nagiosplugin.ScalarContext('service', '1:1', '1:1', fmt_metric=''),
                                DockerSummary())
 
     check.main(args.verbose, args.timeout)

--- a/check_docker
+++ b/check_docker
@@ -44,7 +44,7 @@ class Docker(nagiosplugin.Resource):
 
             metrics = [
                 nagiosplugin.Metric(
-                    'service', self.docker_running),
+                    'service', int(self.docker_running)),
                 nagiosplugin.Metric('images', self.images, context='default'),
                 nagiosplugin.Metric(
                     'go_routines', self.go_routines, context='default'),
@@ -55,7 +55,7 @@ class Docker(nagiosplugin.Resource):
             ]
 
         else:
-            metrics = [nagiosplugin.Metric('service', self.docker_running)]
+            metrics = [nagiosplugin.Metric('service', int(self.docker_running))]
 
         return metrics
 


### PR DESCRIPTION
Hello,

check_docker returned ok when the user running the plugin did not have sufficient privileges to access the docker url, and critical when the user had them. The reason for this:  True in python converts to 1 which surpasses the threshold of 0. 

I adapted the thresholds according to https://nagios-plugins.org/doc/guidelines.html#THRESHOLDFORMAT and converted the booleans to int for more usable performanc data.

Best

  Patricia
